### PR TITLE
4 terraform unit tests should skip upload sarif file if run checkov action was skipped

### DIFF
--- a/.github/workflows/tf-unit-tests.yml
+++ b/.github/workflows/tf-unit-tests.yml
@@ -38,6 +38,7 @@ jobs:
       # Perform a security scan of the terraform code using checkov
       # TODO: How to exclude example directories?
       - name: Run Checkov action
+        if: success() || failure()
         id: checkov
         uses: bridgecrewio/checkov-action@master
         with:

--- a/publicdns.tf
+++ b/publicdns.tf
@@ -73,7 +73,7 @@ module "returnsnulldotcom" {
 
 module "awkwardweirdterribleandbaddotcom" {
   source              = "./modules/publicdns"
-  zone_name           = "awkwardweirdterribleandbad.com"
+  zone_name         = "awkwardweirdterribleandbad.com"
   resource_group_name = azurerm_resource_group.this.name
   a_records = {
     "twilio" = {

--- a/publicdns.tf
+++ b/publicdns.tf
@@ -73,7 +73,7 @@ module "returnsnulldotcom" {
 
 module "awkwardweirdterribleandbaddotcom" {
   source              = "./modules/publicdns"
-  zone_name         = "awkwardweirdterribleandbad.com"
+  zone_name           = "awkwardweirdterribleandbad.com"
   resource_group_name = azurerm_resource_group.this.name
   a_records = {
     "twilio" = {


### PR DESCRIPTION
- Adds conditional to ensure Chekov runs regardless of `fmt` status. 
- Addresses #4. 